### PR TITLE
Copy-pasted new transpose code

### DIFF
--- a/locale/el/messages.po
+++ b/locale/el/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-02-19 08:00+0000\n"
+"POT-Creation-Date: 2020-02-19 08:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: el\n"
@@ -43,23 +43,23 @@ msgstr ""
 msgid "_spec.parameters.varcol.name"
 msgstr ""
 
-#: reshape.py:237
+#: reshape.py:239
 msgid "transpose.warnings.tooManyRows"
 msgstr ""
 
-#: reshape.py:256
+#: reshape.py:258
 msgid "transpose.warnings.headersConvertedToText.message"
 msgstr ""
 
-#: reshape.py:263
+#: reshape.py:265
 msgid "transpose.warnings.headersConvertedToText.quickFix.text"
 msgstr ""
 
-#: reshape.py:298
+#: reshape.py:300
 msgid "transpose.warnings.differentColumnTypes.message"
 msgstr ""
 
-#: reshape.py:305
+#: reshape.py:307
 msgid "transpose.warnings.differentColumnTypes.quickFix.text"
 msgstr ""
 

--- a/locale/el/messages.po
+++ b/locale/el/messages.po
@@ -1,0 +1,65 @@
+# Greek translations for PROJECT.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-02-19 08:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: el\n"
+"Language-Team: el <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+msgid "_spec.name"
+msgstr ""
+
+msgid "_spec.description"
+msgstr ""
+
+msgid "_spec.parameters.direction.options.widetolong.label"
+msgstr ""
+
+msgid "_spec.parameters.direction.options.longtowide.label"
+msgstr ""
+
+msgid "_spec.parameters.direction.options.transpose.label"
+msgstr ""
+
+msgid "_spec.parameters.colnames.name"
+msgstr ""
+
+msgid "_spec.parameters.has_second_key.name"
+msgstr ""
+
+msgid "_spec.parameters.varcol.name"
+msgstr ""
+
+#: reshape.py:237
+msgid "transpose.warnings.tooManyRows"
+msgstr ""
+
+#: reshape.py:256
+msgid "transpose.warnings.headersConvertedToText.message"
+msgstr ""
+
+#: reshape.py:263
+msgid "transpose.warnings.headersConvertedToText.quickFix.text"
+msgstr ""
+
+#: reshape.py:298
+msgid "transpose.warnings.differentColumnTypes.message"
+msgstr ""
+
+#: reshape.py:305
+msgid "transpose.warnings.differentColumnTypes.quickFix.text"
+msgstr ""
+

--- a/locale/en/messages.po
+++ b/locale/en/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-02-19 08:00+0000\n"
+"POT-Creation-Date: 2020-02-19 08:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -43,28 +43,28 @@ msgstr "2nd row variable"
 msgid "_spec.parameters.varcol.name"
 msgstr "Column variable"
 
-#: reshape.py:237
+#: reshape.py:239
 msgid "transpose.warnings.tooManyRows"
 msgstr ""
 "We truncated the input to {max_columns} rows so the transposed table "
 "would have a reasonable number of columns."
 
-#: reshape.py:256
+#: reshape.py:258
 msgid "transpose.warnings.headersConvertedToText.message"
 msgstr "Headers in column \"{column_name}\" were auto-converted to text."
 
-#: reshape.py:263
+#: reshape.py:265
 msgid "transpose.warnings.headersConvertedToText.quickFix.text"
 msgstr "Convert {column_name} to text"
 
-#: reshape.py:298
+#: reshape.py:300
 msgid "transpose.warnings.differentColumnTypes.message"
 msgstr ""
 "{n_columns, plural, other {# columns (see \"{first_colname}\") were} one "
 "{Column \"{first_colname}\" was}} auto-converted to Text because all "
 "columns must have the same type."
 
-#: reshape.py:305
+#: reshape.py:307
 msgid "transpose.warnings.differentColumnTypes.quickFix.text"
 msgstr "Convert {n_columns, plural, other {# columns} one {# column}} to text"
 

--- a/locale/en/messages.po
+++ b/locale/en/messages.po
@@ -1,0 +1,70 @@
+# English translations for PROJECT.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-02-19 08:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+msgid "_spec.name"
+msgstr "Reshape"
+
+msgid "_spec.description"
+msgstr "Convert the table between wide and long formats."
+
+msgid "_spec.parameters.direction.options.widetolong.label"
+msgstr "Wide to long"
+
+msgid "_spec.parameters.direction.options.longtowide.label"
+msgstr "Long to wide"
+
+msgid "_spec.parameters.direction.options.transpose.label"
+msgstr "Transpose"
+
+msgid "_spec.parameters.colnames.name"
+msgstr "Row variable"
+
+msgid "_spec.parameters.has_second_key.name"
+msgstr "2nd row variable"
+
+msgid "_spec.parameters.varcol.name"
+msgstr "Column variable"
+
+#: reshape.py:237
+msgid "transpose.warnings.tooManyRows"
+msgstr ""
+"We truncated the input to {max_columns} rows so the transposed table "
+"would have a reasonable number of columns."
+
+#: reshape.py:256
+msgid "transpose.warnings.headersConvertedToText.message"
+msgstr "Headers in column \"{column_name}\" were auto-converted to text."
+
+#: reshape.py:263
+msgid "transpose.warnings.headersConvertedToText.quickFix.text"
+msgstr "Convert {column_name} to text"
+
+#: reshape.py:298
+msgid "transpose.warnings.differentColumnTypes.message"
+msgstr ""
+"{n_columns, plural, other {# columns (see \"{first_colname}\") were} one "
+"{Column \"{first_colname}\" was}} auto-converted to Text because all "
+"columns must have the same type."
+
+#: reshape.py:305
+msgid "transpose.warnings.differentColumnTypes.quickFix.text"
+msgstr "Convert {n_columns, plural, other {# columns} one {# column}} to text"
+

--- a/locale/templates/messages.pot
+++ b/locale/templates/messages.pot
@@ -31,27 +31,27 @@ msgid "_spec.parameters.varcol.name"
 msgstr ""
 
 #. default-message: We truncated the input to {max_columns} rows so the transposed table would have a reasonable number of columns.
-#: reshape.py:237
+#: reshape.py:239
 msgid "transpose.warnings.tooManyRows"
 msgstr ""
 
 #. default-message: Headers in column "{column_name}" were auto-converted to text.
-#: reshape.py:256
+#: reshape.py:258
 msgid "transpose.warnings.headersConvertedToText.message"
 msgstr ""
 
 #. default-message: Convert {column_name} to text
-#: reshape.py:263
+#: reshape.py:265
 msgid "transpose.warnings.headersConvertedToText.quickFix.text"
 msgstr ""
 
 #. default-message: {n_columns, plural, other {# columns (see "{first_colname}") were} one {Column "{first_colname}" was}} auto-converted to Text because all columns must have the same type.
-#: reshape.py:298
+#: reshape.py:300
 msgid "transpose.warnings.differentColumnTypes.message"
 msgstr ""
 
 #. default-message: Convert {n_columns, plural, other {# columns} one {# column}} to text
-#: reshape.py:305
+#: reshape.py:307
 msgid "transpose.warnings.differentColumnTypes.quickFix.text"
 msgstr ""
 

--- a/locale/templates/messages.pot
+++ b/locale/templates/messages.pot
@@ -1,0 +1,57 @@
+#. default-message: Reshape
+msgid "_spec.name"
+msgstr ""
+
+#. default-message: Convert the table between wide and long formats.
+msgid "_spec.description"
+msgstr ""
+
+#. default-message: Wide to long
+msgid "_spec.parameters.direction.options.widetolong.label"
+msgstr ""
+
+#. default-message: Long to wide
+msgid "_spec.parameters.direction.options.longtowide.label"
+msgstr ""
+
+#. default-message: Transpose
+msgid "_spec.parameters.direction.options.transpose.label"
+msgstr ""
+
+#. default-message: Row variable
+msgid "_spec.parameters.colnames.name"
+msgstr ""
+
+#. default-message: 2nd row variable
+msgid "_spec.parameters.has_second_key.name"
+msgstr ""
+
+#. default-message: Column variable
+msgid "_spec.parameters.varcol.name"
+msgstr ""
+
+#. default-message: We truncated the input to {max_columns} rows so the transposed table would have a reasonable number of columns.
+#: reshape.py:237
+msgid "transpose.warnings.tooManyRows"
+msgstr ""
+
+#. default-message: Headers in column "{column_name}" were auto-converted to text.
+#: reshape.py:256
+msgid "transpose.warnings.headersConvertedToText.message"
+msgstr ""
+
+#. default-message: Convert {column_name} to text
+#: reshape.py:263
+msgid "transpose.warnings.headersConvertedToText.quickFix.text"
+msgstr ""
+
+#. default-message: {n_columns, plural, other {# columns (see "{first_colname}") were} one {Column "{first_colname}" was}} auto-converted to Text because all columns must have the same type.
+#: reshape.py:298
+msgid "transpose.warnings.differentColumnTypes.message"
+msgstr ""
+
+#. default-message: Convert {n_columns, plural, other {# columns} one {# column}} to text
+#: reshape.py:305
+msgid "transpose.warnings.differentColumnTypes.quickFix.text"
+msgstr ""
+

--- a/reshape.py
+++ b/reshape.py
@@ -4,6 +4,8 @@ import pandas as pd
 from pandas.api.types import is_numeric_dtype, is_datetime64_dtype
 from dataclasses import dataclass
 from cjwmodule.util.colnames import gen_unique_clean_colnames_and_warn
+from cjwmodule import i18n
+
 
 def wide_to_long(table: pd.DataFrame, colname: str) -> pd.DataFrame:
     # Check all values are the same type

--- a/reshape.py
+++ b/reshape.py
@@ -2,10 +2,8 @@ from typing import Iterator, List, Set
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype, is_datetime64_dtype
-
-
-MAX_N_COLUMNS = 100
-
+from dataclasses import dataclass
+from cjwmodule.util.colnames import gen_unique_clean_colnames
 
 def wide_to_long(table: pd.DataFrame, colname: str) -> pd.DataFrame:
     # Check all values are the same type
@@ -184,14 +182,106 @@ def migrate_params(params):
 # 1. Find the bug in the `transpose` module. Unit-test it; fix; deploy.
 # 2. Copy/paste the `transpose` module's "render()" method here.
 # 3. Rename `render(...)` to `transpose(table, params)`
+# hard-code settings for now. TODO have Workbench pass render(..., settings=...)
+@dataclass
+class Settings:
+    MAX_COLUMNS_PER_TABLE: int
+    MAX_BYTES_PER_COLUMN_NAME: int
+
+
+settings = Settings(99, 120)
+
+
+@dataclass
+class GenColnamesResult:
+    names: List[str]
+    """All column names for the output table (even the first column)."""
+
+    warnings: List[str]
+    """All the things we should tell the user about how we tweaked names."""
+
+
+def _gen_colnames_and_warn(
+    first_colname: str, first_column: pd.Series
+) -> GenColnamesResult:
+    """
+    Generate transposed-table column names.
+
+    If `first_colname` is empty, `column.name` is the first output column. If
+    both are empty, auto-generate the column name (and warn).
+
+    Warn if ASCII-cleaning names, renaming duplicates, truncating names or
+    auto-generating names.
+
+    Assume `first_column` is text without nulls.
+    """
+    n_ascii_cleaned = 0
+    first_ascii_cleaned = None
+    n_default = 0
+    first_default = None
+    n_truncated = 0
+    first_truncated = None
+    n_numbered = 0
+    first_numbered = None
+
+    input_names = [first_colname or first_column.name]
+    input_names.extend(list(first_column.values))
+
+    names = []
+
+    for uccolname in gen_unique_clean_colnames(input_names, settings=settings):
+        name = uccolname.name
+        names.append(name)
+        if uccolname.is_ascii_cleaned:
+            if n_ascii_cleaned == 0:
+                first_ascii_cleaned = name
+            n_ascii_cleaned += 1
+        if uccolname.is_default:
+            if n_default == 0:
+                first_default = name
+            n_default += 1
+        if uccolname.is_truncated:
+            if n_truncated == 0:
+                first_truncated = name
+            n_truncated += 1
+        if uccolname.is_numbered:
+            if n_numbered == 0:
+                first_numbered = name
+            n_numbered += 1
+
+    warnings = []
+    if n_ascii_cleaned > 0:
+        warnings.append(
+            "Removed special characters from %d column names (see “%s”)"
+            % (n_ascii_cleaned, first_ascii_cleaned)
+        )
+    if n_default > 0:
+        warnings.append(
+            "Renamed %d column names (because values were empty; see “%s”)"
+            % (n_default, first_default)
+        )
+    if n_truncated > 0:
+        warnings.append(
+            "Truncated %d column names (to %d bytes each; see “%s”)"
+            % (n_truncated, settings.MAX_BYTES_PER_COLUMN_NAME, first_truncated)
+        )
+    if n_numbered > 0:
+        warnings.append(
+            "Renamed %d duplicate column names (see “%s”)"
+            % (n_numbered, first_numbered)
+        )
+
+    return GenColnamesResult(names, warnings)
+
+
 def transpose(table, params, *, input_columns):
     warnings = []
     colnames_auto_converted_to_text = []
 
-    if len(table) > MAX_N_COLUMNS:
-        table = table.truncate(after=MAX_N_COLUMNS - 1)
+    if len(table) > settings.MAX_COLUMNS_PER_TABLE:
+        table = table.truncate(after=settings.MAX_COLUMNS_PER_TABLE - 1)
         warnings.append(
-            f"We truncated the input to {MAX_N_COLUMNS} rows so the "
+            f"We truncated the input to {settings.MAX_COLUMNS_PER_TABLE} rows so the "
             "transposed table would have a reasonable number of columns."
         )
 
@@ -199,57 +289,24 @@ def transpose(table, params, *, input_columns):
         # happens if we're the first module in the module stack
         return pd.DataFrame()
 
-    # If user does not supply a name (default), use the input table's first
-    # column name as the output table's first column name.
-    first_colname = params["firstcolname"].strip() or table.columns[0]
-
     column = table.columns[0]
-    headers_series = table[column]
+    first_column = table[column]
     table.drop(column, axis=1, inplace=True)
 
-    # Ensure headers are string. (They will become column names.)
     if input_columns[column].type != "text":
         warnings.append(f'Headers in column "A" were auto-converted to text.')
         colnames_auto_converted_to_text.append(column)
 
-    # Regardless of column type, we want to convert to str. This catches lots
-    # of issues:
-    #
-    # * Column names shouldn't be a CategoricalIndex; that would break other
-    #   Pandas functions. See https://github.com/pandas-dev/pandas/issues/19136
-    # * nulls should be converted to '' instead of 'nan'
-    # * Non-str should be converted to str
-    # * `first_colname` will be the first element (so we can enforce its
-    #   uniqueness).
-    #
-    # After this step, `headers` will be a List[str]. "" is okay for now: we'll
-    # catch that later.
-    na = headers_series.isna()
-    headers_series = headers_series.astype(str)
-    headers_series[na] = ""  # Empty values are all equivalent
-    headers_series[headers_series.isna()] = ""
-    headers = headers_series.tolist()
-    headers.insert(0, first_colname)
-    non_empty_headers = [h for h in headers if h]
+    # Ensure headers are string. (They will become column names.)
+    # * categorical => str
+    # * nan => ""
+    # * non-text => str
+    na = first_column.isna()
+    first_column = first_column.astype(str)
+    first_column[na] = ""  # Empty values are all equivalent
 
-    # unique_headers: all the "valuable" header names -- the ones we won't
-    # rename any duplicate/empty headers to.
-    unique_headers = set(headers)
-
-    if "" in unique_headers:
-        warnings.append(
-            f'We renamed some columns because the input column "{column}" had '
-            "empty values."
-        )
-    if len(non_empty_headers) != len(unique_headers - set([""])):
-        warnings.append(
-            f'We renamed some columns because the input column "{column}" had '
-            "duplicate values."
-        )
-
-    headers = list(_uniquize_colnames(headers, unique_headers))
-
-    table.index = headers[1:]
+    gen_headers_result = _gen_colnames_and_warn(params["firstcolname"], first_column)
+    warnings.extend(gen_headers_result.warnings)
 
     input_types = set(c.type for c in input_columns.values() if c.name != column)
     if len(input_types) > 1:
@@ -274,9 +331,10 @@ def transpose(table, params, *, input_columns):
             table[colname][na] = np.nan
 
     # The actual transpose
+    table.index = gen_headers_result.names[1:]
     ret = table.T
     # Set the name of the index: it will become the name of the first column.
-    ret.index.name = first_colname
+    ret.index.name = gen_headers_result.names[0]
     # Make the index (former colnames) a column
     ret.reset_index(inplace=True)
 
@@ -291,7 +349,7 @@ def transpose(table, params, *, input_columns):
                     "action": "prependModule",
                     "args": [
                         "converttotext",
-                        {"colnames": ",".join(colnames_auto_converted_to_text)},
+                        {"colnames": colnames_auto_converted_to_text},
                     ],
                 }
             ],
@@ -300,34 +358,4 @@ def transpose(table, params, *, input_columns):
         return (ret, "\n".join(warnings))
     else:
         return ret
-
-
-def _uniquize_colnames(
-    colnames: Iterator[str], never_rename_to: Set[str]
-) -> Iterator[str]:
-    """
-    Rename columns to prevent duplicates or empty column names.
-
-    The algorithm: iterate over each `colname` and add to an internal "seen".
-    When we encounter a colname we've seen, append " 1", " 2", " 3", etc. to it
-    until we encounter a colname we've never seen that is not in
-    `never_rename_to`.
-    """
-    seen = set()
-    for colname in colnames:
-        force_add_number = False
-        if not colname:
-            colname = "unnamed"
-            force_add_number = "unnamed" in never_rename_to
-        if colname in seen or force_add_number:
-            for i in range(1, 999999):
-                try_colname = f"{colname} {i}"
-                if try_colname not in seen and try_colname not in never_rename_to:
-                    colname = try_colname
-                    break
-
-        seen.add(colname)
-        yield colname
-
-
 # END copy/paste


### PR DESCRIPTION
This pull request is meant to prepare `transpose` in this module for i18n. I just copy-pasted the current code from the `transpose` module, as per the instructions above the `transpose` function of this module. I haven't looked into the changes thoroughly, hence I'm not sure if (or to what extent) they are equivalent to the old behaviour; I hope it will be easy for you (@adamhooper) though, because your are way more familiar with the modules.